### PR TITLE
SADX: Fix typo in the Sky Chase settings

### DIFF
--- a/Sonic Adventure DX- Director-s Cut/LiveSplit.SADX.asl
+++ b/Sonic Adventure DX- Director-s Cut/LiveSplit.SADX.asl
@@ -152,7 +152,7 @@ startup
 	settings.Add("charStartBanTrial", false, "Don't start when in trial");
 	
 	settings.Add("stages",true,"Stages NOT To Split");
-		settings.Add("36",true,"Sky Chace Act 1","stages");
+		settings.Add("36",true,"Sky Chase Act 1","stages");
 		settings.Add("37",true,"Sky Chase Act 2","stages");
 	
 	settings.Add("bosses",true,"Final Boss To Split");

--- a/Sonic Adventure DX- Director-s Cut/LiveSplit.SADXIGT.ExT.asl
+++ b/Sonic Adventure DX- Director-s Cut/LiveSplit.SADXIGT.ExT.asl
@@ -159,7 +159,7 @@ startup
 	settings.Add("centurionEntry", false, "Start on Enter", "KCC");
 	
 	settings.Add("stages",true,"Stages NOT To Split");
-		settings.Add("36",true,"Sky Chace Act 1","stages");
+		settings.Add("36",true,"Sky Chase Act 1","stages");
 		settings.Add("37",true,"Sky Chase Act 2","stages");
 	
 	settings.Add("bosses",true,"Final Boss To Split");


### PR DESCRIPTION
From 'Sky Chace' to 'Sky Chase'